### PR TITLE
fix(piped image): For PRIVATE_BOT_MODE calls

### DIFF
--- a/AlexaMusic/core/call.py
+++ b/AlexaMusic/core/call.py
@@ -172,8 +172,8 @@ class Call(PyTgCalls):
         else:
             if image and config.PRIVATE_BOT_MODE == str(True):
                 stream = MediaStream(
-                    link,
                     image,
+                    audio_path=link,
                     audio_parameters=audio_stream_quality,
                     video_parameters=video_stream_quality,
                 )
@@ -238,8 +238,8 @@ class Call(PyTgCalls):
         else:
             if image and config.PRIVATE_BOT_MODE == str(True):
                 stream = MediaStream(
-                    link,
                     image,
+                    audio_path=link,
                     audio_parameters=audio_stream_quality,
                     video_parameters=video_stream_quality,
                 )
@@ -345,8 +345,8 @@ class Call(PyTgCalls):
                         image = None
                     if image and config.PRIVATE_BOT_MODE == str(True):
                         stream = MediaStream(
-                            link,
                             image,
+                            audio_path=link,
                             audio_parameters=audio_stream_quality,
                             video_parameters=video_stream_quality,
                         )
@@ -405,8 +405,8 @@ class Call(PyTgCalls):
                         image = None
                     if image and config.PRIVATE_BOT_MODE == str(True):
                         stream = MediaStream(
-                            file_path,
                             image,
+                            audio_path=file_path,
                             audio_parameters=audio_stream_quality,
                             video_parameters=video_stream_quality,
                         )
@@ -489,8 +489,8 @@ class Call(PyTgCalls):
                 else:
                     if image and config.PRIVATE_BOT_MODE == str(True):
                         stream = MediaStream(
-                            queued,
                             image,
+                            audio_path=queued,
                             audio_parameters=audio_stream_quality,
                             video_parameters=video_stream_quality,
                         )


### PR DESCRIPTION
Radhe radhe!

```python
            if image and config.PRIVATE_BOT_MODE == str(True):
                stream = MediaStream(
                    link,
                    image,
                    audio_parameters=audio_stream_quality,
                    video_parameters=video_stream_quality,
                )
```
As default there are no parameter for link and image so MediaStream thinks that that link is `media_path` that Would be played/displayed and image is `audio_parameters` That is cause of `TypeError` This should be like as below 
```python
            if image and config.PRIVATE_BOT_MODE == str(True):
                stream = MediaStream(
                    image,
                    audio_path=link,
                    audio_parameters=audio_stream_quality,
                    video_parameters=video_stream_quality,
                )
```
In this image is defaults to `media_path` that is displayed and link is as `audio_path` that will be played