### PR TITLE
Fixed inline back button issue in group chats by correcting settings_…

### DIFF
--- a/AlexaMusic/plugins/bot/settings.py
+++ b/AlexaMusic/plugins/bot/settings.py
@@ -93,7 +93,7 @@ async def settings_cb(client, CallbackQuery, _):
 @app.on_callback_query(filters.regex("settingsback_helper") & ~BANNED_USERS)
 @languageCB
 async def settings_back_markup(
-    client, CallbackQuery: CallbackQuery, _, message: Message
+    client, CallbackQuery: CallbackQuery, _
 ):
     try:
         await CallbackQuery.answer()
@@ -107,7 +107,7 @@ async def settings_back_markup(
             OWNER = None
         buttons = private_panel(_, app.username, OWNER)
         return await CallbackQuery.edit_message_text(
-            caption=_["start_2"].format(message.from_user.mention, app.mention),
+            caption=_["start_2"].format(CallbackQuery.from_user.mention, app.mention),
             reply_markup=InlineKeyboardMarkup(buttons),
         )
     else:


### PR DESCRIPTION
…back_markup() argument

The inline back button was not functioning properly when pressed inside group chats, though it worked fine in private messages with the bot. The root cause was identified as a missing argument 'message' in the 'settings_back_markup()' function call.     

Fixed-Error: Pyrogram.dispatcher - settings_back_markup() missing 1 
TypeError: settings_back_markup() missing 1 required positional argument: 'message'